### PR TITLE
Решение проблемы когда сайт работает в кодировке windows-1251

### DIFF
--- a/.last_version/install/components/vasoft/sendpulse/class.php
+++ b/.last_version/install/components/vasoft/sendpulse/class.php
@@ -123,6 +123,7 @@ class VasoftSendpulseComponent extends CBitrixComponent
 				if (!$obBook->active) {
 					++$this->arResult['INACTIVE'];
 				}
+				if (LANG_CHARSET === "windows-1251") $obBook->name = Sendpulse\Utils::detectAndConvertToWin($obBook->name);
 				$this->arResult['LISTS'][$obBook->id] = $obBook;
 			}
 			$arUserInfo = $api->getEmailGlobalInfo($this->arResult['EMAIL']);

--- a/.last_version/lib/utils.php
+++ b/.last_version/lib/utils.php
@@ -1,0 +1,33 @@
+<?
+namespace Vasoft\Sendpulse;
+
+class Utils
+{
+    /*Рекрусивная смена кодировки значений массива*/
+    public static function mbConvertArray($array)
+    {
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $array[$key] = self::mbConvertArray($value);
+            } else {
+                $array[$key] = self::detectAndConvertToWin($value);
+            }
+        }
+        return $array;
+    }
+
+    public static function detectEncode($string)
+    {
+        return mb_detect_encoding($string, implode(',', mb_list_encodings()));
+    }
+
+    public static function detectAndConvertToWin($string)
+    {
+        if ($string && detectEncode($string) == "UTF-8") {
+            return mb_convert_encoding($string, "windows-1251", "UTF-8");
+        }
+        return $string;
+    }
+
+}
+?>

--- a/.last_version/options.php
+++ b/.last_version/options.php
@@ -304,6 +304,7 @@ if ($MODULE_RIGHT >= "W" && Loader::includeModule($module_id)) {
 			else:
 				$prevSeparator = false;
 				foreach ($arViewOptions2 as $arOption):
+					if (LANG_CHARSET === "windows-1251") $arOption['OPTIONS']['LIST'] = Sendpulse\Utils::mbConvertArray($arOption['OPTIONS']['LIST']);
 					if ($arOption['TAB'] != $arTab['DIV']) continue;
 					if (isset($arOption['SEPARATOR'])):
 						if ($prevSeparator) continue;


### PR DESCRIPTION
названия по АПИ прилетают в UTF-8, однако сайты работающие еще на кодировке windows-1251 в админке и в компоненте не корректно отображают названия подписок, данный костыль должен это исправить!